### PR TITLE
fix(ci): Fix issue where CI does not run for PR when commits are pushed with 'ok-to-test' label

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@ BLACK_FMT:=$(PY) -m black
 .PHONY: deps format run run-trials
 
 run: dep-pip
-	env REAL_TIME=False $(PY) HAL.py
+	$(PY) HAL.py
 	
 run-trials: dep-pip
 	$(PY) HALTrials.py


### PR DESCRIPTION
Fix issue where CI does not run for PR when commits are pushed with 'ok-to-test' label:
-  it only runs the label is added or removed, but not when new are  pushed to PR with the 'ok-to-test' label.